### PR TITLE
Fix Parking by-law filter always matching zero buildings

### DIFF
--- a/BuildingBlocks/BuildingBlockSystem.cs
+++ b/BuildingBlocks/BuildingBlockSystem.cs
@@ -338,12 +338,13 @@ namespace ZoningByLaw.BuildingBlocks
                 case ByLawItemType.LotWidth:
                 case ByLawItemType.LotSize:
                 case ByLawItemType.LotDepth:
-                case ByLawItemType.Parking:
                 case ByLawItemType.FrontSetback:
                 case ByLawItemType.LeftSetback:
                 case ByLawItemType.RightSetback:
                 case ByLawItemType.RearSetback:
                     return ByLawConstraintType.Length;
+                case ByLawItemType.Parking:
+                    return ByLawConstraintType.Count;
                 case ByLawItemType.NoisePollutionLevel:
                 case ByLawItemType.GroundPollutionLevel:
                 case ByLawItemType.AirPollutionLevel:

--- a/Serialization/ByLawRecord.cs
+++ b/Serialization/ByLawRecord.cs
@@ -11,6 +11,7 @@ using Trejak.ZoningByLaw.Prefab;
 using Trejak.ZoningByLaw.UISystems;
 using Unity.Collections;
 using UnityEngine;
+using ZoningByLaw.BuildingBlocks;
 
 namespace Trejak.ZoningByLaw.Serialization
 {
@@ -380,7 +381,12 @@ namespace Trejak.ZoningByLaw.Serialization
             return new BuildingBlocks.ByLawItem
             {
                 byLawItemType = parsedItemType,
-                constraintType = Enum.TryParse<BuildingBlocks.ByLawConstraintType>(constraintType, out var ct) ? ct : BuildingBlocks.ByLawConstraintType.None,
+                // Recomputed from itemType rather than trusted from the serialized value: constraintType is
+                // purely a function of byLawItemType (see BuildingBlockSystem.GetConstraintTypes), never a
+                // user choice, so this also self-heals saves written while a type's mapping was wrong
+                // (e.g. Parking was misclassified as Length instead of Count, which made every Parking
+                // by-law item silently fail to match any building).
+                constraintType = BuildingBlockSystem.GetConstraintTypes(parsedItemType),
                 itemCategory = Enum.TryParse<BuildingBlocks.ByLawItemCategory>(itemCategory, out var ic) ? ic : BuildingBlocks.ByLawItemCategory.None,
                 propertyOperator = Enum.TryParse<BuildingBlocks.ByLawPropertyOperator>(propertyOperator, out var po) ? po : BuildingBlocks.ByLawPropertyOperator.None,
                 valueBounds1 = valueBounds1.ToBounds1(),

--- a/Tests/BuildingBlocks/ParkingEvaluationTests.cs
+++ b/Tests/BuildingBlocks/ParkingEvaluationTests.cs
@@ -1,0 +1,60 @@
+using Colossal.Mathematics;
+using Trejak.ZoningByLaw.BuildingBlocks;
+using Unity.Assertions;
+using Unity.Entities;
+using ZoningByLaw.BuildingBlocks;
+
+namespace Trejak.ZoningByLaw.Tests.BuildingBlocks
+{
+    public class ParkingEvaluationTests
+    {
+        [Test]
+        public void TestGetConstraintTypes_Parking_ReturnsCount()
+        {
+            // Parking was previously misclassified as Length, which routed it to EvaluateLength (no
+            // Parking case, always false) instead of EvaluateCount (which has the real Parking logic).
+            Assert.IsTrue(BuildingBlockSystem.GetConstraintTypes(ByLawItemType.Parking) == ByLawConstraintType.Count,
+                "Parking must be classified as Count so evaluation dispatch reaches EvaluateCount");
+        }
+
+        [Test]
+        public void TestEvaluateCount_Parking_MatchesWhenWithinBounds()
+        {
+            var item = new ByLawItem
+            {
+                byLawItemType = ByLawItemType.Parking,
+                constraintType = ByLawConstraintType.Count,
+                propertyOperator = ByLawPropertyOperator.Is,
+                valueBounds1 = new Bounds1(1, 3)
+            };
+            var properties = new BuildingByLawProperties
+            {
+                initialized = true,
+                parkingCount = 2
+            };
+
+            Assert.IsTrue(BuildingBlockSystem.EvaluateCount(Entity.Null, properties, item, default),
+                "A building whose parking count falls within the bounds should match");
+        }
+
+        [Test]
+        public void TestEvaluateCount_Parking_DoesNotMatchWhenOutsideBounds()
+        {
+            var item = new ByLawItem
+            {
+                byLawItemType = ByLawItemType.Parking,
+                constraintType = ByLawConstraintType.Count,
+                propertyOperator = ByLawPropertyOperator.Is,
+                valueBounds1 = new Bounds1(1, 3)
+            };
+            var properties = new BuildingByLawProperties
+            {
+                initialized = true,
+                parkingCount = 0
+            };
+
+            Assert.IsTrue(!BuildingBlockSystem.EvaluateCount(Entity.Null, properties, item, default),
+                "A building whose parking count falls outside the bounds should not match");
+        }
+    }
+}

--- a/Tests/Serialization/ParkingSerializationTests.cs
+++ b/Tests/Serialization/ParkingSerializationTests.cs
@@ -1,0 +1,40 @@
+using Trejak.ZoningByLaw.BuildingBlocks;
+using Trejak.ZoningByLaw.Serialization;
+using Unity.Assertions;
+
+namespace Trejak.ZoningByLaw.Tests.Serialization
+{
+    public class ParkingSerializationTests
+    {
+        [Test]
+        public void TestSerializableByLawItem_LegacyParkingRecord_SelfHealsConstraintTypeToCount()
+        {
+            // Saves written before the Parking mapping fix persisted constraintType="Length" for
+            // Parking items, which routed evaluation to EvaluateLength (no Parking case, always false).
+            // ToByLawItem() must recompute constraintType from byLawItemType instead of trusting the
+            // stored value, so loading such a save repairs the item instead of staying broken.
+            var legacyItem = new SerializableByLawItem
+            {
+                byLawItemType = ByLawItemType.Parking.ToString(),
+                constraintType = ByLawConstraintType.Length.ToString(),
+                itemCategory = ByLawItemCategory.Lot.ToString(),
+                propertyOperator = ByLawPropertyOperator.Is.ToString(),
+                valueNumberArray = new int[0]
+            };
+
+            var byLawItem = legacyItem.ToByLawItem();
+            try
+            {
+                Assert.IsTrue(byLawItem.constraintType == ByLawConstraintType.Count,
+                    $"Legacy Parking records with a stale constraintType must self-heal to Count on load, got {byLawItem.constraintType}");
+            }
+            finally
+            {
+                if (byLawItem.valueNumberArray.IsCreated)
+                {
+                    byLawItem.valueNumberArray.Dispose();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #23 — the Parking by-law filter always showed 0 eligible buildings and no buildings would spawn when the zone was painted.

**Root cause:** `BuildingBlockSystem.GetConstraintTypes()` classified `ByLawItemType.Parking` as `ByLawConstraintType.Length`. `Evaluate()` dispatches on that constraint type, and `EvaluateLength()` has no case for `Parking`, so it fell through to `default: return false`. The working Parking logic actually lives in `EvaluateCount()` (which does have a `Parking` case), but it was never reached because the item's stored constraint type routed it to the wrong evaluator. The UI's own TypeScript mapping (`getConstraintTypes` in `UI/src/mods/utils.ts`) already had this correct (`Parking → Count`), so this was a C#-side-only inconsistency.

- Reclassified `Parking → ByLawConstraintType.Count` in `BuildingBlockSystem.GetConstraintTypes`, matching the UI and `EvaluateCount`'s existing case.
- `constraintType` is persisted per by-law item but is purely a function of `byLawItemType` (never a user choice), so `ByLawRecord.ToByLawItem()` now recomputes it from the item type on load instead of trusting the serialized value. This makes existing saves that already contain a broken Parking by-law self-heal on next load, rather than requiring the by-law to be deleted and recreated.

## Test plan
- [ ] In-game: add a Parking by-law filter to a zone with a min/max bound and confirm eligible buildings > 0 and buildings spawn.
- [ ] Load a save created before this fix that has a Parking by-law configured, and confirm it now evaluates correctly without needing to re-add the item.
